### PR TITLE
Fix Paper 1.21.11 compatibility for v1_21_R7 and v26_1_base

### DIFF
--- a/impl/v1_21_R7/src/main/java/de/derfrzocker/custom/ore/generator/impl/v1_21_R7/ChunkAccessImpl.java
+++ b/impl/v1_21_R7/src/main/java/de/derfrzocker/custom/ore/generator/impl/v1_21_R7/ChunkAccessImpl.java
@@ -18,16 +18,25 @@ public class ChunkAccessImpl
         extends BlockStateListPopulator
         implements ChunkAccess {
 
+    private final LevelAccessor world;
     private final Set<BlockPos> blockPosSet = new HashSet<>();
     private final Consumer<BlockPos> blockSet = blockPosSet::add;
 
     public ChunkAccessImpl(LevelAccessor world) {
         super(world);
+        this.world = world;
+    }
+    
+    // In Paper 1.21.11, getWorld() was removed from BlockStateListPopulator
+    public LevelAccessor getWorld() {
+        return world;
     }
 
     @Override
     public void setMaterial(@NotNull Material material, int x, int y, int z) {
-        setBlock(new BlockPos(x, y, z), ((CraftBlockData) material.createBlockData()).getState(), 3);
+        BlockPos pos = new BlockPos(x, y, z);
+        setBlock(pos, ((CraftBlockData) material.createBlockData()).getState(), 3);
+        blockPosSet.add(pos);
     }
 
     @NotNull
@@ -47,9 +56,9 @@ public class ChunkAccessImpl
 
     @Override
     public Set<BlockPos> getBlocks() {
-        Set<BlockPos> blockPos = new HashSet<>(super.getBlocks());
-        blockPos.addAll(blockPosSet);
-        return blockPos;
+        // In Paper 1.21.11, getBlocks() was removed from BlockStateListPopulator
+        // We track blocks ourselves in blockPosSet (populated in setMaterial)
+        return new HashSet<>(blockPosSet);
     }
 
     @Override

--- a/impl/v1_21_R7/src/main/java/de/derfrzocker/custom/ore/generator/impl/v1_21_R7/CustomOrePopulator.java
+++ b/impl/v1_21_R7/src/main/java/de/derfrzocker/custom/ore/generator/impl/v1_21_R7/CustomOrePopulator.java
@@ -114,8 +114,8 @@ public class CustomOrePopulator extends BlockPopulator {
 
         ChunkAccessImpl chunkAccess = new ChunkAccessImpl(((CraftLimitedRegion) limitedRegion).getHandle());
         oreGenerator.generate(oreConfig, chunkAccess, chunkX, chunkZ, random, biome, biomeLocations);
-        chunkAccess.refreshTiles();
-        chunkAccess.updateList();
+        // refreshTiles() and updateList() methods were removed in Paper 1.21.11
+        // Tile entities are now handled automatically by the new BlockStateListPopulator API
         for (BlockPos pos : chunkAccess.getBlocks()) {
             oreConfig.getCustomData().forEach((customData, object) -> customData.getCustomDataApplier().apply(oreConfig, new Location(null, pos.getX(), pos.getY(), pos.getZ()), limitedRegion));
         }

--- a/impl/v26_1_base/src/main/java/de/derfrzocker/custom/ore/generator/impl/v26_1_base/ChunkAccessImpl.java
+++ b/impl/v26_1_base/src/main/java/de/derfrzocker/custom/ore/generator/impl/v26_1_base/ChunkAccessImpl.java
@@ -16,16 +16,25 @@ import org.jetbrains.annotations.NotNull;
 
 public class ChunkAccessImpl extends BlockStateListPopulator implements ChunkAccess {
 
+    private final LevelAccessor world;
     private final Set<BlockPos> blockPosSet = new HashSet<>();
     private final Consumer<BlockPos> blockSet = blockPosSet::add;
 
     public ChunkAccessImpl(LevelAccessor world) {
         super(world);
+        this.world = world;
+    }
+    
+    // In Paper 1.21.11, getWorld() was removed from BlockStateListPopulator
+    public LevelAccessor getWorld() {
+        return world;
     }
 
     @Override
     public void setMaterial(@NotNull Material material, int x, int y, int z) {
-        setBlock(new BlockPos(x, y, z), ((CraftBlockData) material.createBlockData()).getState(), 3);
+        BlockPos pos = new BlockPos(x, y, z);
+        setBlock(pos, ((CraftBlockData) material.createBlockData()).getState(), 3);
+        blockPosSet.add(pos);
     }
 
     @NotNull
@@ -45,9 +54,9 @@ public class ChunkAccessImpl extends BlockStateListPopulator implements ChunkAcc
 
     @Override
     public Set<BlockPos> getBlocks() {
-        Set<BlockPos> blockPos = new HashSet<>(super.getBlocks());
-        blockPos.addAll(blockPosSet);
-        return blockPos;
+        // In Paper 1.21.11, getBlocks() was removed from BlockStateListPopulator
+        // We track blocks ourselves in blockPosSet (populated in setMaterial)
+        return new HashSet<>(blockPosSet);
     }
 
     @Override

--- a/impl/v26_1_base/src/main/java/de/derfrzocker/custom/ore/generator/impl/v26_1_base/CustomOrePopulator.java
+++ b/impl/v26_1_base/src/main/java/de/derfrzocker/custom/ore/generator/impl/v26_1_base/CustomOrePopulator.java
@@ -166,8 +166,8 @@ public class CustomOrePopulator extends BlockPopulator {
 
         ChunkAccessImpl chunkAccess = new ChunkAccessImpl(((CraftLimitedRegion) limitedRegion).getHandle());
         oreGenerator.generate(oreConfig, chunkAccess, chunkX, chunkZ, random, biome, biomeLocations);
-        chunkAccess.refreshTiles();
-        chunkAccess.updateList();
+        // refreshTiles() and updateList() methods were removed in Paper 1.21.11
+        // Tile entities are now handled automatically by the new BlockStateListPopulator API
         for (BlockPos pos : chunkAccess.getBlocks()) {
             oreConfig
                     .getCustomData()


### PR DESCRIPTION
## Summary
Fixes compatibility issues with Paper 1.21.11 where `BlockStateListPopulator` API was changed, causing `NoSuchMethodError` crashes during world generation.

## Problem
In Paper 1.21.11, several methods were removed from `BlockStateListPopulator`:
- `refreshTiles()`
- `updateList()`
- `getBlocks()`
- `getWorld()`

This caused the plugin to crash with `NoSuchMethodError` when generating ores.

## Solution
### ChunkAccessImpl changes:
- Added `LevelAccessor world` field to store world reference
- Implemented `getWorld()` method to replace removed parent method
- Modified `setMaterial()` to track block positions in `blockPosSet`
- Overridden `getBlocks()` to return tracked blocks instead of calling removed parent method

### CustomOrePopulator changes:
- Removed calls to deleted `refreshTiles()` and `updateList()` methods
- Added comments explaining why these methods were removed

## Affected modules
- `impl/v1_21_R7` (Paper 1.21.11)
- `impl/v26_1_base` (Paper 26.1)

## Testing
Tested on Paper 1.21.11 server - plugin now works without crashes during ore generation.

## Related Issues
Fixes #50 - Crash on 1.21+ PaperMC server with `NoSuchMethodError: 'net.minecraft.world.level.LevelAccessor ChunkAccessImpl.getWorld()'`